### PR TITLE
breaking/camera tracking enable disable

### DIFF
--- a/QscQsysDspPlugin/QscDsp.cs
+++ b/QscQsysDspPlugin/QscDsp.cs
@@ -111,6 +111,8 @@ namespace QscQsysDspPlugin
         private string _password;
         public string DspName { get; private set; }
 
+        public string AutoTrackingKey { get; set; }
+
 
         /// <summary>
         /// Constructor
@@ -220,6 +222,15 @@ namespace QscQsysDspPlugin
             {
                 prefix = props.Prefix;
             }
+
+            AutoTrackingKey = string.Format("{0}-{1}", Key, "Auto-Tracking");
+
+            LevelControlPoints.Add(AutoTrackingKey, new QscDspLevelControl("Auto-Tracking", new QscDspLevelControlBlockConfig
+                                                                                            {
+                                                                                                HasMute = true,
+                                                                                                Label = AutoTrackingKey,
+                                                                                                MuteInstanceTag = "CAM_TRACK" //todo make configurable
+                                                                                            }, this));
 
             if (props.LevelControlBlocks != null)
             {

--- a/QscQsysDspPlugin/QscDspBridge.cs
+++ b/QscQsysDspPlugin/QscDspBridge.cs
@@ -48,13 +48,24 @@ namespace QscQsysDspPlugin
             trilist.SetStringSigAction(joinMap.SimTxRx.JoinNumber, DspDevice.ProcessSimulatedRx);
 
 			foreach (var channel in DspDevice.LevelControlPoints)
-			{
-				//var QscChannel = channel.Value as QSC.DSP.EPI.QscDspLevelControl;
-				Debug.Console(2, "QscChannel {0} connect", x);
+            {
+                if (channel.Key == DspDevice.AutoTrackingKey)
+                {
+                    Debug.Console(2, DspDevice, "Found autotracking... skipping");
+                    var actualChannel = channel.Value;
+                    trilist.SetSigTrueAction(joinMap.AutoTracking.JoinNumber, actualChannel.MuteToggle);
+                    actualChannel.MuteFeedback.LinkInputSig(trilist.BooleanInput[joinMap.AutoTracking.JoinNumber]);
+                    continue;
+                }
 
+				//var QscChannel = channel.Value as QSC.DSP.EPI.QscDspLevelControl;
+			    Debug.Console(2, "QscChannel {0} connect", x);
+                
 				var genericChannel = channel.Value as IBasicVolumeWithFeedback;
 				if (channel.Value.Enabled)
-				{
+                {
+                    Debug.Console(2, DspDevice, "Linking Level Control:{0} at index:{1}", channel.Key, x);
+
 					// from SiMPL > to Plugin
                     trilist.StringInput[joinMap.ChannelName.JoinNumber + x].StringValue = channel.Value.LevelCustomName;
                     trilist.UShortInput[joinMap.ChannelType.JoinNumber + x].UShortValue = (ushort)channel.Value.Type;
@@ -558,6 +569,19 @@ namespace QscQsysDspPlugin
             {
                 Description = "Device Name",
                 JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+        [JoinName("AutoTracking")]
+        public JoinDataComplete AutoTracking = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 10,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "AutoTracking Enable Disable",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
                 JoinType = eJoinType.Serial
             });
 

--- a/QscQsysDspPlugin/QscDspCameraBridge.cs
+++ b/QscQsysDspPlugin/QscDspCameraBridge.cs
@@ -48,8 +48,8 @@ namespace QscQsysDspPlugin
                 trilist.SetSigTrueAction(joinMap.PresetStoreStart.JoinNumber + temp + 1, () => camera.SavePreset(temp));
                 trilist.SetStringSigAction(joinMap.PresetNamesStart.JoinNumber + temp, (s) => camera.WritePresetName(s, (ushort)(temp + 1)));
                 // from Plugin > to SiMPL
-                preset.Value.LabelFeedback.LinkInputSig(trilist.StringInput[joinMap.PresetNamesStart.JoinNumber + temp]);
-
+                preset.Value.LabelFeedback.LinkInputSig(trilist.StringInput[joinMap.PresetNamesStart.JoinNumber + temp + 1]);
+                trilist.SetString(joinMap.PresetNamesStart.JoinNumber + temp + 1, preset.Value.Label);
                 x++;
             }
 
@@ -266,7 +266,7 @@ namespace QscQsysDspPlugin
         public JoinDataComplete PresetNamesStart = new JoinDataComplete(
             new JoinData
             {
-                JoinNumber = 2,
+                JoinNumber = 10,
                 JoinSpan = 20
             },
             new JoinMetadata


### PR DESCRIPTION
- this change is technically breaking as it moves the preset name outputs to the bridge to match VideoCameraBase