### PR TITLE
feat: faders increment can be set from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Update the configuration object as needed for the plugin being developed.
 }
 ```
 
-### Plugin Level Control Configuration Object
+### Plugin Level Control Configuration Object  Note: "incrementAmount" is set to 2 by default        
+
 
 ```json
 "properties": {
@@ -85,7 +86,8 @@ Update the configuration object as needed for the plugin being developed.
 			"hasMute": true,
 			"isMic": false,
 			"useAbsoluteValue": false,
-			"unmuteOnVolChange": true
+			"unmuteOnVolChange": true,
+			"incrementAmount": 1        
 		},
 		"fader-program": {
 			"label": "Program",
@@ -96,7 +98,8 @@ Update the configuration object as needed for the plugin being developed.
 			"hasMute": true,
 			"isMic": false,
 			"useAbsoluteValue": false,
-			"unmuteOnVolChange": true
+			"unmuteOnVolChange": true,
+			"incrementAmount": 1
 		},
 		"fader-speech": {
 			"label": "Speech",
@@ -107,7 +110,8 @@ Update the configuration object as needed for the plugin being developed.
 			"hasMute": true,
 			"isMic": false,
 			"useAbsoluteValue": false,
-			"unmuteOnVolChange": true
+			"unmuteOnVolChange": true,
+			"incrementAmount": 1
 		},
 		"fader-phone-call": {
 			"label": "Phone Call",
@@ -118,7 +122,8 @@ Update the configuration object as needed for the plugin being developed.
 			"hasMute": true,
 			"isMic": false,
 			"useAbsoluteValue": false,
-			"unmuteOnVolChange": true
+			"unmuteOnVolChange": true,
+			"incrementAmount": 1
 		},
 		"fader-video-call": {
 			"label": "Video Call",
@@ -129,7 +134,8 @@ Update the configuration object as needed for the plugin being developed.
 			"hasMute": true,
 			"isMic": false,
 			"useAbsoluteValue": false,
-			"unmuteOnVolChange": true
+			"unmuteOnVolChange": true,
+			"incrementAmount": 1
 		},
 		"fader-privacy": {
 			"label": "Privacy",
@@ -140,7 +146,8 @@ Update the configuration object as needed for the plugin being developed.
 			"hasMute": true,
 			"isMic": true,
 			"useAbsoluteValue": false,
-			"unmuteOnVolChange": true
+			"unmuteOnVolChange": true,
+			"incrementAmount": 1
 		},
 		"fader-wireless-mics": {
 			"label": "Wireless Mics",
@@ -151,7 +158,8 @@ Update the configuration object as needed for the plugin being developed.
 			"hasMute": true,
 			"isMic": true,
 			"useAbsoluteValue": false,
-			"unmuteOnVolChange": true
+			"unmuteOnVolChange": true,
+			"incrementAmount": 1
 		},
 		"fader-8": {
 			"label": "Fader 8",

--- a/output/QscQsysDspPlugin.4Series.3.0.0-local.cplz
+++ b/output/QscQsysDspPlugin.4Series.3.0.0-local.cplz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4816e897e46cb910b49dd469c3ab187676095ee8aa904fc1fe50ebc895b893ed
-size 38590
+oid sha256:794be9387dba8dde7c86bfa2d9258d734a5af98cd614ad3bf9282980385894f0
+size 38738

--- a/output/QscQsysDspPlugin.4Series.3.0.0-local.cplz
+++ b/output/QscQsysDspPlugin.4Series.3.0.0-local.cplz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:794be9387dba8dde7c86bfa2d9258d734a5af98cd614ad3bf9282980385894f0
+oid sha256:ccdf0ae8ee513f2a5abc7554cd55bd32875fb322be735872b72527cea5cf6c3a
 size 38738

--- a/src/QscDspLevelControl.cs
+++ b/src/QscDspLevelControl.cs
@@ -134,7 +134,7 @@ namespace QscQsysDspPlugin
             _volumeUpRepeatTimer = new CTimer(VolumeUpRepeat, Timeout.Infinite);
             _volumeDownRepeatTimer = new CTimer(VolumeDownRepeat, Timeout.Infinite);
             _volumeRampDelay = new CTimer(VolumeRampStop, Timeout.Infinite);
-            _incrementAmount = config.IncrementAmount > 0 ? config.IncrementAmount : 1;
+            _incrementAmount = config.IncrementAmount > 0 ? config.IncrementAmount : 2;
 
             LevelCustomName = config.Label;
             HasMute = config.HasMute;

--- a/src/QscDspLevelControl.cs
+++ b/src/QscDspLevelControl.cs
@@ -16,7 +16,9 @@ namespace QscQsysDspPlugin
 
 		public IntFeedback VolumeLevelFeedback { get; private set; }
 
-		public bool Enabled { get; set; }
+        private int _incrementAmount = 1; // Default value
+
+        public bool Enabled { get; set; }
 		public bool UseAbsoluteValue { get; set; }
 
 		public ePdtLevelTypes Type;
@@ -131,8 +133,9 @@ namespace QscQsysDspPlugin
 
             _volumeUpRepeatTimer = new CTimer(VolumeUpRepeat, Timeout.Infinite);
             _volumeDownRepeatTimer = new CTimer(VolumeDownRepeat, Timeout.Infinite);
-
             _volumeRampDelay = new CTimer(VolumeRampStop, Timeout.Infinite);
+            _incrementAmount = config.IncrementAmount > 0 ? config.IncrementAmount : 1;
+
             LevelCustomName = config.Label;
             HasMute = config.HasMute;
             HasLevel = config.HasLevel;
@@ -294,9 +297,9 @@ namespace QscQsysDspPlugin
                 _volumeUpRepeatTimer.Stop();
 
                 _volumeDownRepeatTimer.Reset(_rampResetTime);
-				SendFullCommand("css ", this.LevelInstanceTag, "--");
-			}
-			else
+                SendFullCommand("css ", this.LevelInstanceTag, new string('-', _incrementAmount));
+                }
+            else
 			{
                 _volumeRampTracker = false;
 				_volumeDownRepeatTimer.Stop();
@@ -317,9 +320,9 @@ namespace QscQsysDspPlugin
                 _volumeDownRepeatTimer.Stop();
 
                 _volumeUpRepeatTimer.Reset(_rampResetTime);
-				SendFullCommand("css ", this.LevelInstanceTag, "++");
+                SendFullCommand("css ", this.LevelInstanceTag, new string('+', _incrementAmount));
 
-				if (AutomaticUnmuteOnVolumeUp && !_isMuted) MuteOff();
+                if (AutomaticUnmuteOnVolumeUp && !_isMuted) MuteOff();
 			}
 			else
 			{

--- a/src/QscDspPropertiesConfig.cs
+++ b/src/QscDspPropertiesConfig.cs
@@ -166,7 +166,10 @@ namespace QscQsysDspPlugin
 
 		[JsonProperty("unmuteOnVolChange")]
 		public bool UnmuteOnVolChange { get; set; }
-	}
+
+        [JsonProperty("incrementAmount")]
+        public int IncrementAmount { get; set; } = 2; // Default to 2 step
+        }
 
 
 


### PR DESCRIPTION
This pull request introduces a new feature to support configurable volume increment amounts in the QSC DSP plugin. It updates both the plugin's configuration and core functionality to handle this feature. The changes include updates to the documentation, configuration schema, and implementation logic.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R75): Added a new property, `"incrementAmount"`, to the configuration examples for various fader types. This property allows users to specify the volume increment step size, with a default value of 1. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R90) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R102) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R114) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R126) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R138) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R150) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L154-R162)

### Configuration Schema Updates:
* [`src/QscDspPropertiesConfig.cs`](diffhunk://#diff-bd4a576d6b264341a8f81662e2c1c07b8f02f6bbca9bba83737b1bb1196071dcR169-R171): Introduced a new `incrementAmount` property in the `QscDspLevelControlBlockConfig` class with a default value of 2. This property is serialized/deserialized using JSON.

### Core Functionality Updates:
* `src/QscDspLevelControl.cs`:
  - Added a private `_incrementAmount` field to store the configured increment value, defaulting to 1.
  - Updated the `Initialize` method to set `_incrementAmount` based on the configuration, ensuring a fallback to 1 if the value is invalid.
  - Modified `VolumeUp` and `VolumeDown` methods to use `_incrementAmount` for determining the number of volume steps. [[1]](diffhunk://#diff-0592e5138e67295b6812eae5a8bd5ec1f188b360d595fe7d0c86029c95bb40bcL297-R300) [[2]](diffhunk://#diff-0592e5138e67295b6812eae5a8bd5ec1f188b360d595fe7d0c86029c95bb40bcL320-R323)

### Plugin File Update:
* [`output/QscQsysDspPlugin.4Series.3.0.0-local.cplz`](diffhunk://#diff-56c849bcadf59f02691ff4d634484bffd218b56910c7bb2a022cd7fd9cdd0a74L2-R3): Updated the plugin binary to reflect the changes in functionality and configuration.