### PR TITLE
feat!: migrate plugin to Essentials v3 (net8)

### DIFF
--- a/src/QscDsp.cs
+++ b/src/QscDsp.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Crestron.SimplSharp;
-using Crestron.SimplSharp.Reflection;
+using System.Reflection;
 using Crestron.SimplSharpPro.DeviceSupport;
 using Newtonsoft.Json;
 using PepperDash.Core;
@@ -104,7 +104,7 @@ namespace QscQsysDspPlugin
         {
             _Dc = dc;
             var props = JsonConvert.DeserializeObject<QscDspPropertiesConfig>(dc.Properties.ToString());
-            Debug.Console(2, this, "Made it to device constructor");
+            this.LogDebug("Made it to device constructor");
 
             CommandQueue = new CrestronQueue(100);
             Communication = comm;
@@ -151,7 +151,7 @@ namespace QscQsysDspPlugin
         /// CustomActivate Override
         /// </summary>
         /// <returns></returns>
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             CrestronConsole.AddNewConsoleCommand(SendLine, "send" + Key, "", ConsoleAccessLevelEnum.AccessOperator);
             CrestronConsole.AddNewConsoleCommand(s => Communication.Connect(), "con" + Key, "",
@@ -221,7 +221,7 @@ namespace QscQsysDspPlugin
                     value.MuteInstanceTag = FormatTag(prefix, value.MuteInstanceTag);
 
                     this.LevelControlPoints.Add(key, new QscDspLevelControl(key, value, this));
-                    Debug.Console(2, this, "Added LevelControlPoint {0} LevelTag: {1} MuteTag: {2}", key,
+                    this.LogDebug("Added LevelControlPoint {Key} LevelTag: {LevelTag} MuteTag: {MuteTag}", key,
                         value.LevelInstanceTag, value.MuteInstanceTag);
                 }
             }
@@ -241,7 +241,7 @@ namespace QscQsysDspPlugin
                     value.Preset = string.Format("{0}{1}", prefix, value.Preset);
                     this.AddPreset(value);
                     Presets.Add(preset.Key, qsysPreset);
-                    Debug.Console(2, this, "Added Preset {0} {1}", value.Label, value.Preset);
+                    this.LogDebug("Added Preset {Label} {Preset}", value.Label, value.Preset);
                 }
             }
             if (props.CameraControlBlocks != null)
@@ -266,7 +266,7 @@ namespace QscQsysDspPlugin
                     }
 
                     Cameras.Add(key, new QscDspCamera(this, key, key, value));
-                    Debug.Console(2, this, "Added Camera {0}\n {1}", key, value);
+                    this.LogDebug("Added Camera {Key}\n {Value}", key, value);
                 }
             }
             if (props.DialerControlBlocks != null)
@@ -299,7 +299,7 @@ namespace QscQsysDspPlugin
                     value.KeypadPoundTag = FormatTag(prefix, value.KeypadPoundTag);
                     value.KeypadStarTag = FormatTag(prefix, value.KeypadStarTag);
                     this.Dialers.Add(key, new QscDspDialer(value, this));
-                    Debug.Console(2, this, "Added Dialer {0}\n {1}", key, value);
+                    this.LogDebug("Added Dialer {Key}\n {Value}", key, value);
                 }
             }
             SubscribeToAttributes();
@@ -321,7 +321,7 @@ namespace QscQsysDspPlugin
                 if (hostname.Length > 2 &
                     _Dc.Properties["control"]["tcpSshProperties"]["address"].ToString() != hostname)
                 {
-                    Debug.Console(2, this, "Changing IPAddress: {0}", hostname);
+                    this.LogDebug("Changing IPAddress: {Hostname}", hostname);
                     Communication.Disconnect();
 
                     (Communication as GenericTcpIpClient).Hostname = hostname;
@@ -333,8 +333,7 @@ namespace QscQsysDspPlugin
             }
             catch (Exception e)
             {
-                if (Debug.Level == 2)
-                    Debug.Console(2, this, "Error SetIpAddress: '{0}'", e);
+                this.LogDebug(e, "Error SetIpAddress");
             }
         }
 
@@ -349,8 +348,7 @@ namespace QscQsysDspPlugin
                 _Dc.Properties["prefix"] = prefix;
                 CustomSetConfig(_Dc);
                 // CreateDspObjects();
-                Debug.ConsoleWithLog(0, this,
-                    "The Dsp Prefix has changed to {0} the program will automaticly restart in 60 seconds", prefix);
+                this.LogInformation("The Dsp Prefix has changed to {Prefix} the program will automatically restart in 60 seconds", prefix);
                 string notUsed = "";
                 CTimer restart =
                     new CTimer(
@@ -391,19 +389,18 @@ namespace QscQsysDspPlugin
 
             if (HeartbeatTracker > 0)
             {
-                Debug.Console(1, this, "Heartbeat missed, count {0}", HeartbeatTracker);
+                this.LogInformation("Heartbeat missed, count {HeartbeatTracker}", HeartbeatTracker);
                 if (HeartbeatTracker % 5 == 0)
                 {
-                    Debug.Console(1, this, "Heartbeat missed 5 times, subscriptions lost? Resubscribing now");
+                    this.LogInformation("Heartbeat missed 5 times, subscriptions lost? Resubscribing now");
                     if (HeartbeatTracker == 5)
-                        Debug.LogError(Debug.ErrorLogLevel.Warning,
-                            "Heartbeat missed 5 times - subscriptions lost? Attempting resubscribe.");
+                        this.LogWarning("Heartbeat missed 5 times - subscriptions lost? Attempting resubscribe.");
                     SubscribeToAttributes();
                 }
             }
             else
             {
-                Debug.Console(2, this, "Heartbeat okay");
+                this.LogDebug("Heartbeat okay");
             }
         }
 
@@ -461,7 +458,7 @@ namespace QscQsysDspPlugin
                 {
                     if (string.IsNullOrEmpty(_username) || string.IsNullOrEmpty(_password))
                     {
-                        Debug.Console(0, this, "DEVICE REQUIRES LOGIN CREDENTIALS");
+                        this.LogError("DEVICE REQUIRES LOGIN CREDENTIALS");
                         return;
                     }
 
@@ -471,12 +468,12 @@ namespace QscQsysDspPlugin
 
                 if (args.Text.EndsWith("cgpa\r"))
                 {
-                    Debug.Console(2, this, "Found poll response");
+                    this.LogDebug("Found poll response");
                     HeartbeatTracker = 0;
                 }
                 if (args.Text.IndexOf("sr ") > -1)
                 {
-                    Debug.Console(1, this, "Status Response received");
+                    this.LogInformation("Status Response received");
 
                     var statusMessage = Regex.Split(args.Text, " (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
                     //Splits by space unless enclosed in double quotes using look ahead method: https://stackoverflow.com/questions/18893390/splitting-on-comma-outside-quotes
@@ -487,7 +484,7 @@ namespace QscQsysDspPlugin
                     IsPrimary = statusMessage[3].Contains("1") ? true : false;
                     IsActive = statusMessage[4].Contains("1") ? true : false;
 
-                    Debug.Console(1, this, "IsPrimary = {0}{1}:: IsActive = {2}{3}", statusMessage[3], IsPrimary,
+                    this.LogInformation("IsPrimary = {PrimaryMsg}{IsPrimary}:: IsActive = {ActiveMsg}{IsActive}", statusMessage[3], IsPrimary,
                         statusMessage[4], IsActive);
                 }
                 else if (args.Text.IndexOf("cv") > -1)
@@ -496,7 +493,7 @@ namespace QscQsysDspPlugin
                     //Splits by space unless enclosed in double quotes using look ahead method: https://stackoverflow.com/questions/18893390/splitting-on-comma-outside-quotes
 
                     string changedInstance = changeMessage[1].Replace("\"", "");
-                    Debug.Console(2, this, "cv parse Instance: {0}", changedInstance);
+                    this.LogDebug("cv parse Instance: {Instance}", changedInstance);
                     bool foundItFlag = false;
                     foreach (KeyValuePair<string, QscDspLevelControl> controlPoint in LevelControlPoints)
                     {
@@ -520,7 +517,7 @@ namespace QscQsysDspPlugin
                     {
                         foreach (var dialer in Dialers)
                         {
-                            PropertyInfo[] properties = dialer.Value.Tags.GetType().GetCType().GetProperties();
+                            PropertyInfo[] properties = dialer.Value.Tags.GetType().GetProperties();
                             foreach (var prop in properties)
                             {
                                 var propValue = prop.GetValue(dialer.Value.Tags, null) as string;
@@ -551,7 +548,7 @@ namespace QscQsysDspPlugin
                     {
                         foreach (var camera in Cameras)
                         {
-                            Debug.Console(2, this, "DSP Camera Status Compare: {0} ==? {1}", changedInstance,
+                            this.LogDebug("DSP Camera Status Compare: {Instance} ==? {OnlineStatus}", changedInstance,
                                 camera.Value.Config.OnlineStatus);
                             if (changedInstance == camera.Value.Config.OnlineStatus)
                             {
@@ -570,8 +567,7 @@ namespace QscQsysDspPlugin
             }
             catch (Exception e)
             {
-                if (Debug.Level == 2)
-                    Debug.Console(2, this, "Port_LineRecieved Exception: '{0}'\n{1}", args.Text, e);
+                this.LogDebug(e, "Port_LineReceived Exception: '{Text}'", args.Text);
             }
         }
 

--- a/src/QscDsp.cs
+++ b/src/QscDsp.cs
@@ -318,7 +318,7 @@ namespace QscQsysDspPlugin
         {
             try
             {
-                if (hostname.Length > 2 &
+                if (hostname.Length > 2 &&
                     _Dc.Properties["control"]["tcpSshProperties"]["address"].ToString() != hostname)
                 {
                     this.LogDebug("Changing IPAddress: {Hostname}", hostname);

--- a/src/QscDspBridge.cs
+++ b/src/QscDspBridge.cs
@@ -59,7 +59,7 @@ namespace QscQsysDspPlugin
                 }
 
 				//var QscChannel = channel.Value as QSC.DSP.EPI.QscDspLevelControl;
-DspDevice.LogDebug("QscChannel {Index} connect", x);
+			DspDevice.LogDebug("QscChannel {Index} connect", x);
                 
 				var genericChannel = channel.Value as IBasicVolumeWithFeedback;
 				if (channel.Value.Enabled)

--- a/src/QscDspBridge.cs
+++ b/src/QscDspBridge.cs
@@ -1,8 +1,8 @@
 using System.Linq;
-using Crestron.SimplSharp.Reflection;
 using Crestron.SimplSharpPro.DeviceSupport;
 using Newtonsoft.Json;
 using PepperDash.Core;
+using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Bridges;
 
@@ -26,7 +26,7 @@ namespace QscQsysDspPlugin
             }
             //if (joinMap == null)
             //    joinMap = new QscDspCameraDeviceJoinMap();
-            Debug.Console(1, DspDevice, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
+            DspDevice.LogInformation("Linking to Trilist '{TrilistId}'", trilist.ID.ToString("X"));
 			ushort x = 0;
 			var comm = DspDevice as ICommunicationMonitor;
 
@@ -51,7 +51,7 @@ namespace QscQsysDspPlugin
             {
                 if (channel.Key == DspDevice.AutoTrackingKey)
                 {
-                    Debug.Console(2, DspDevice, "Found autotracking... skipping");
+                    DspDevice.LogDebug("Found autotracking... skipping");
                     var actualChannel = channel.Value;
                     trilist.SetSigTrueAction(joinMap.AutoTracking.JoinNumber, actualChannel.MuteToggle);
                     actualChannel.MuteFeedback.LinkInputSig(trilist.BooleanInput[joinMap.AutoTracking.JoinNumber]);
@@ -59,12 +59,12 @@ namespace QscQsysDspPlugin
                 }
 
 				//var QscChannel = channel.Value as QSC.DSP.EPI.QscDspLevelControl;
-			    Debug.Console(2, DspDevice, "QscChannel {0} connect", x);
+DspDevice.LogDebug("QscChannel {Index} connect", x);
                 
 				var genericChannel = channel.Value as IBasicVolumeWithFeedback;
 				if (channel.Value.Enabled)
                 {
-                    Debug.Console(2, DspDevice, "Linking Level Control:{0} at index:{1}", channel.Key, x);
+                    DspDevice.LogDebug("Linking Level Control:{Key} at index:{Index}", channel.Key, x);
 
 					// from SiMPL > to Plugin
                     trilist.StringInput[joinMap.ChannelName.JoinNumber + x].StringValue = channel.Value.LevelCustomName;
@@ -112,7 +112,7 @@ namespace QscQsysDspPlugin
 				var dialer = line;
 
 				var dialerLineOffset = lineOffset;
-				Debug.Console(0, "AddingDialerBridge {0} {1} Offset", dialer.Key, dialerLineOffset);
+				Debug.LogMessage(Serilog.Events.LogEventLevel.Information, "AddingDialerBridge {Key} {Offset} Offset", null, dialer.Key, dialerLineOffset);
 				
 				// from SiMPL > to Plugin
                 trilist.SetSigTrueAction((joinMap.Keypad0.JoinNumber + dialerLineOffset), () => DspDevice.Dialers[dialer.Key].SendKeypad(QscDspDialer.EKeypadKeys.Num0));
@@ -169,132 +169,6 @@ namespace QscQsysDspPlugin
 			}
 		}
 	}
-
-#if SERIES3
-
-    /// <summary>
-    /// QSC DSP Join Map
-    /// </summary>
-    public class QscDspDeviceJoinMap : JoinMapBase
-	{
-		public uint IsOnline { get; set; }
-        public uint IsPrimary { get; set; }
-        public uint IsSecondary { get; set; }
-        public uint IsActive { get; set; }
-        public uint SimTxRx { get; set; }
-        public uint IsInactive { get; set; }
-        public uint GetStatus { get; set; }
-        public uint DspName { get; set; }
-		public uint Address { get; set; }
-		public uint Prefix { get; set; }
-		public uint ChannelMuteToggle { get; set; }
-		public uint ChannelMuteOn { get; set; }
-		public uint ChannelMuteOff { get; set; }
-		public uint ChannelVolume { get; set; }
-		public uint ChannelType { get; set; }
-		public uint ChannelName { get; set; }
-		public uint ChannelVolumeUp { get; set; }
-		public uint ChannelVolumeDown { get; set; }
-		public uint Presets { get; set; }
-		public uint DialStringCmd { get; set; }
-		public uint IncomingCall { get; set; }
-		public uint Keypad0 { get; set; }
-		public uint Keypad1 { get; set; }
-		public uint Keypad2 { get; set; }
-		public uint Keypad3 { get; set; }
-		public uint Keypad4 { get; set; }
-		public uint Keypad5 { get; set; }
-		public uint Keypad6 { get; set; }
-		public uint Keypad7 { get; set; }
-		public uint Keypad8 { get; set; }
-		public uint Keypad9 { get; set; }
-		public uint KeypadStar { get; set; }
-		public uint KeypadPound { get; set; }
-		public uint KeypadClear { get; set; }
-		public uint KeypadBackspace { get; set; }
-		public uint Dial { get; set; }
-		public uint DoNotDisturbToggle { get; set; }
-		public uint DoNotDisturbOn { get; set; }
-		public uint DoNotDisturbOff { get; set; }
-		public uint AutoAnswerToggle { get; set; }
-		public uint AutoAnswerOn { get; set; }
-		public uint AutoAnswerOff { get; set; }
-		public uint OffHook { get; set; }
-		public uint OnHook { get; set; }
-		public uint ChannelVisible { get; set; }
-		public uint CallerIdNumberFb { get; set; }
-		public uint EndCall { get; set; }
-		public uint IncomingCallAccept { get; set; }
-		public uint IncomingCallReject { get; set; }
-
-		public QscDspDeviceJoinMap()
-		{
-			// Arrays
-			ChannelName = 200;
-			ChannelMuteToggle = 400;
-			ChannelMuteOn = 600;
-			ChannelMuteOff = 800;
-			ChannelVolume = 200;
-			ChannelVolumeUp = 1000;
-			ChannelVolumeDown = 1200;
-			ChannelType = 400;
-			Presets = 100;
-			ChannelVisible = 200;
-
-			// SIngleJoins
-			IsOnline = 1;
-            IsPrimary = 2;
-            IsSecondary = 3;
-            IsActive = 4;
-            IsInactive = 5;
-            SimTxRx = 6;
-            GetStatus = 2;
-			Prefix = 2;
-			Address = 1;
-            DspName = 3;
-			Presets = 100;
-			DialStringCmd = 3100;
-			IncomingCall = 3100;
-			EndCall = 3107;
-			Keypad0 = 3110;
-			Keypad1 = 3111;
-			Keypad2 = 3112;
-			Keypad3 = 3113;
-			Keypad4 = 3114;
-			Keypad5 = 3115;
-			Keypad6 = 3116;
-			Keypad7 = 3117;
-			Keypad8 = 3118;
-			Keypad9 = 3119;
-			KeypadStar = 3120;
-			KeypadPound = 3121;
-			KeypadClear = 3122;
-			KeypadBackspace = 3123;
-			DoNotDisturbToggle = 3132;
-			DoNotDisturbOn = 3133;
-			DoNotDisturbOff = 3134;
-			AutoAnswerToggle = 3127;
-			AutoAnswerOn = 3125;
-			AutoAnswerOff = 3126;
-			Dial = 3124;
-			OffHook = 3130;
-			OnHook = 3129;
-			CallerIdNumberFb = 3104;
-			IncomingCallAccept = 3136;
-			IncomingCallReject = 3137;
-		}
-
-		public override void OffsetJoinNumbers(uint joinStart)
-		{
-			var joinOffset = joinStart - 1;
-			var properties = this.GetType().GetCType().GetProperties().Where(o => o.PropertyType == typeof(uint)).ToList();
-			foreach (var property in properties)
-			{
-				property.SetValue(this, (uint)property.GetValue(this, null) + joinOffset, null);
-			}
-		}
-	}
-#endif
 
     public class QscDspDeviceJoinMapAdvanced : JoinMapBaseAdvanced
     {

--- a/src/QscDspCamera.cs
+++ b/src/QscDspCamera.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Crestron.SimplSharpPro.DeviceSupport;
 using PepperDash.Core;
+using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Bridges;
 
@@ -104,7 +105,7 @@ namespace QscQsysDspPlugin
 		/// <param name="presetNumber">ushort</param>
 		public void RecallPreset(ushort presetNumber)
 		{
-			Debug.Console(2, this, "Recall Camera Preset {0}", presetNumber);
+			this.LogDebug("Recall Camera Preset {PresetNumber}", presetNumber);
 			if (Config.Presets.ElementAt(presetNumber).Value != null)
 			{
 				var preset = Config.Presets.ElementAt(presetNumber).Value;
@@ -160,7 +161,7 @@ namespace QscQsysDspPlugin
 			}
 			catch (Exception e)
 			{
-				Debug.Console(2, "QscDspCamera Subscription Error: '{0}'\n", e);
+				Debug.LogMessage(Serilog.Events.LogEventLevel.Debug, "QscDspCamera Subscription Error: '{Error}'\n", null, e);
 			}
 		}
 
@@ -174,7 +175,7 @@ namespace QscQsysDspPlugin
 		{
 
 			// Check for valid subscription response
-			Debug.Console(1, this, "CameraOnline {0} Response: '{1}'", customName, value);
+			this.LogInformation("CameraOnline {CustomName} Response: '{Value}'", customName, value);
 
 			if (value == "true")
 			{

--- a/src/QscDspCamera.cs
+++ b/src/QscDspCamera.cs
@@ -161,7 +161,7 @@ namespace QscQsysDspPlugin
 			}
 			catch (Exception e)
 			{
-				Debug.LogMessage(Serilog.Events.LogEventLevel.Debug, "QscDspCamera Subscription Error: '{Error}'\n", null, e);
+				Debug.LogMessage(Serilog.Events.LogEventLevel.Debug, e, "QscDspCamera Subscription Error");
 			}
 		}
 

--- a/src/QscDspCameraBridge.cs
+++ b/src/QscDspCameraBridge.cs
@@ -1,5 +1,6 @@
 using Crestron.SimplSharpPro.DeviceSupport;
 using PepperDash.Core;
+using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Bridges;
 
@@ -24,7 +25,7 @@ namespace QscQsysDspPlugin
             //if (joinMap == null)
             //    joinMap = new QscDspCameraDeviceJoinMap();
 
-            Debug.Console(1, camera, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
+            camera.LogInformation("Linking to Trilist '{TrilistId}'", trilist.ID.ToString("X"));
 
             // from Plugin > to SiMPL
             camera.IsOnline.LinkInputSig(trilist.BooleanInput[joinMap.Online.JoinNumber]);

--- a/src/QscDspDialer.cs
+++ b/src/QscDspDialer.cs
@@ -204,7 +204,7 @@ namespace QscQsysDspPlugin
 			}
 			catch (Exception e)
 			{
-				Debug.LogMessage(LogEventLevel.Debug, "QscDspDialer Subscription Error: '{Error}'\n", null, e);
+				Debug.LogMessage(LogEventLevel.Debug, e, "QscDspDialer Subscription Error");
 			}
 
 			// SendSubscriptionCommand(, "1");

--- a/src/QscDspDialer.cs
+++ b/src/QscDspDialer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
-using Crestron.SimplSharp.Reflection;
+using System.Reflection;
+using Serilog.Events;
 using Crestron.SimplSharpPro.CrestronThread;
 using PepperDash.Core;
 using PepperDash.Essentials.Core;
@@ -187,23 +188,23 @@ namespace QscQsysDspPlugin
 				// Do subscriptions and blah blah
 				// This would be better using reflection JTA 2018-08-28
 				//PropertyInfo[] properties = Tags.GetType().GetCType().GetProperties();
-				var properties = Tags.GetType().GetCType().GetProperties();
+				var properties = Tags.GetType().GetProperties();
 				//GetPropertyValues(Tags);
 
-				Debug.Console(2, "QscDspDialer Subscribe");
+				Debug.LogMessage(LogEventLevel.Debug, "QscDspDialer Subscribe");
 				foreach (var prop in properties)
 				{
                     if (prop.Name.Contains("Tag") && !prop.Name.ToLower().Contains("keypad"))
 					{
 						var propValue = prop.GetValue(Tags, null) as string;
-						Debug.Console(2, "Property {0}, {1}, {2}\n", prop.GetType().Name, prop.Name, propValue);
+						Debug.LogMessage(LogEventLevel.Debug, "Property {TypeName}, {PropName}, {Value}\n", null, prop.GetType().Name, prop.Name, propValue);
 						SendSubscriptionCommand(propValue);
 					}
 				}
 			}
 			catch (Exception e)
 			{
-				Debug.Console(2, "QscDspDialer Subscription Error: '{0}'\n", e);
+				Debug.LogMessage(LogEventLevel.Debug, "QscDspDialer Subscription Error: '{Error}'\n", null, e);
 			}
 
 			// SendSubscriptionCommand(, "1");
@@ -218,10 +219,10 @@ namespace QscQsysDspPlugin
 		public void ParseSubscriptionMessage(string customName, string value)
 		{
 			// Check for valid subscription response
-			Debug.Console(0, "ParseMessage customName: {0} value: '{1}'", customName, value);
+			Debug.LogMessage(LogEventLevel.Information, "ParseMessage customName: {CustomName} value: '{Value}'", null, customName, value);
 			if (customName == Tags.DialStringTag)
 			{
-				Debug.Console(0, "ParseMessage customName: {0} == Tags.DialStringTag: {1} | value: {2}", customName, Tags.DialStringTag, value);
+				Debug.LogMessage(LogEventLevel.Information, "ParseMessage customName: {CustomName} == Tags.DialStringTag: {DialStringTag} | value: {Value}", null, customName, Tags.DialStringTag, value);
 				DialString = value;
 				DialStringFeedback.FireUpdate();
 			}

--- a/src/QscDspFactory.cs
+++ b/src/QscDspFactory.cs
@@ -9,7 +9,7 @@ namespace QscQsysDspPlugin
     {
         public QscDspFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.0.0";
+            MinimumEssentialsFrameworkVersion = "3.0.0";
             TypeNames = new List<string> { "qscDsp" };
         }
 

--- a/src/QscDspLevelControl.cs
+++ b/src/QscDspLevelControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Crestron.SimplSharp;
 using PepperDash.Core;
+using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 
 namespace QscQsysDspPlugin
@@ -121,7 +122,7 @@ namespace QscQsysDspPlugin
             DeviceManager.AddDevice(this);
             Type = config.IsMic ? ePdtLevelTypes.Microphone : ePdtLevelTypes.Speaker;
 
-            Debug.Console(2, this, "Adding LevelControl '{0}'", Key);
+            this.LogDebug("Adding LevelControl '{Key}'", Key);
 
             this.IsSubscribed = false;
 
@@ -168,7 +169,7 @@ namespace QscQsysDspPlugin
 		public void ParseSubscriptionMessage(string customName, string value, string absoluteValue)
 		{
 			// Check for valid subscription response
-			Debug.Console(1, this, "Level {0} Response: '{1}'", customName, value);
+			this.LogInformation("Level {CustomName} Response: '{Value}'", customName, value);
 			if (
                 !String.IsNullOrEmpty(MuteInstanceTag) 
                 && customName.Equals(MuteInstanceTag, StringComparison.OrdinalIgnoreCase))
@@ -197,7 +198,7 @@ namespace QscQsysDspPlugin
 				var parsedValue = Double.Parse(value);
 
                 _volumeLevel = (ushort)(parsedValue * 65535);
-				Debug.Console(1, this, "Level {0} VolumeLevel: '{1}'", customName, _volumeLevel);
+				this.LogInformation("Level {CustomName} VolumeLevel: '{VolumeLevel}'", customName, _volumeLevel);
 				_levelIsSubscribed = true;
 
 				VolumeLevelFeedback.FireUpdate();
@@ -209,7 +210,7 @@ namespace QscQsysDspPlugin
 			{
 
 				_volumeLevel = ushort.Parse(absoluteValue);
-				Debug.Console(1, this, "Level {0} VolumeLevel: '{1}'", customName, _volumeLevel);
+				this.LogInformation("Level {CustomName} VolumeLevel: '{VolumeLevel}'", customName, _volumeLevel);
 				_levelIsSubscribed = true;
 
 				VolumeLevelFeedback.FireUpdate();
@@ -238,7 +239,7 @@ namespace QscQsysDspPlugin
 		/// <param name="level"></param>
 		public void SetVolume(ushort level)
 		{
-			Debug.Console(1, this, "volume: {0}", level);
+				this.LogInformation("volume: {Level}", level);
 			// Unmute volume if new level is higher than existing
 			if (AutomaticUnmuteOnVolumeUp && _isMuted)
 			{
@@ -247,7 +248,7 @@ namespace QscQsysDspPlugin
 			if (!UseAbsoluteValue)
 			{
 				var newLevel = Scale(level);
-				Debug.Console(1, this, "newVolume: {0}", newLevel);
+				this.LogInformation("newVolume: {NewLevel}", newLevel);
 				SendFullCommand("csp", this.LevelInstanceTag, string.Format("{0}", newLevel));
 			}
 			else
@@ -344,11 +345,11 @@ namespace QscQsysDspPlugin
 		/// <returns></returns>
 		double Scale(double input)
 		{
-			Debug.Console(1, this, "Scaling (double) input '{0}'", input);
+			this.LogInformation("Scaling (double) input '{Input}'", input);
 
 			var output = (input / 65535);
 
-			Debug.Console(1, this, "Scaled output '{0}'", output);
+			this.LogInformation("Scaled output '{Output}'", output);
 
 			return output;
 		}

--- a/src/QscDspLevelControl.cs
+++ b/src/QscDspLevelControl.cs
@@ -239,7 +239,7 @@ namespace QscQsysDspPlugin
 		/// <param name="level"></param>
 		public void SetVolume(ushort level)
 		{
-				this.LogInformation("volume: {Level}", level);
+			this.LogInformation("volume: {Level}", level);
 			// Unmute volume if new level is higher than existing
 			if (AutomaticUnmuteOnVolumeUp && _isMuted)
 			{

--- a/src/QscDspLevelControl.cs
+++ b/src/QscDspLevelControl.cs
@@ -169,7 +169,7 @@ namespace QscQsysDspPlugin
 		public void ParseSubscriptionMessage(string customName, string value, string absoluteValue)
 		{
 			// Check for valid subscription response
-			this.LogInformation("Level {CustomName} Response: '{Value}'", customName, value);
+			this.LogDebug("Level {CustomName} Response: '{Value}'", customName, value);
 			if (
                 !String.IsNullOrEmpty(MuteInstanceTag) 
                 && customName.Equals(MuteInstanceTag, StringComparison.OrdinalIgnoreCase))
@@ -198,7 +198,7 @@ namespace QscQsysDspPlugin
 				var parsedValue = Double.Parse(value);
 
                 _volumeLevel = (ushort)(parsedValue * 65535);
-				this.LogInformation("Level {CustomName} VolumeLevel: '{VolumeLevel}'", customName, _volumeLevel);
+				this.LogDebug("Level {CustomName} VolumeLevel: '{VolumeLevel}'", customName, _volumeLevel);
 				_levelIsSubscribed = true;
 
 				VolumeLevelFeedback.FireUpdate();
@@ -210,7 +210,7 @@ namespace QscQsysDspPlugin
 			{
 
 				_volumeLevel = ushort.Parse(absoluteValue);
-				this.LogInformation("Level {CustomName} VolumeLevel: '{VolumeLevel}'", customName, _volumeLevel);
+				this.LogDebug("Level {CustomName} VolumeLevel: '{VolumeLevel}'", customName, _volumeLevel);
 				_levelIsSubscribed = true;
 
 				VolumeLevelFeedback.FireUpdate();
@@ -239,7 +239,7 @@ namespace QscQsysDspPlugin
 		/// <param name="level"></param>
 		public void SetVolume(ushort level)
 		{
-			this.LogInformation("volume: {Level}", level);
+			this.LogDebug("volume: {Level}", level);
 			// Unmute volume if new level is higher than existing
 			if (AutomaticUnmuteOnVolumeUp && _isMuted)
 			{
@@ -248,7 +248,7 @@ namespace QscQsysDspPlugin
 			if (!UseAbsoluteValue)
 			{
 				var newLevel = Scale(level);
-				this.LogInformation("newVolume: {NewLevel}", newLevel);
+				this.LogDebug("newVolume: {NewLevel}", newLevel);
 				SendFullCommand("csp", this.LevelInstanceTag, string.Format("{0}", newLevel));
 			}
 			else
@@ -345,11 +345,11 @@ namespace QscQsysDspPlugin
 		/// <returns></returns>
 		double Scale(double input)
 		{
-			this.LogInformation("Scaling (double) input '{Input}'", input);
+			this.LogDebug("Scaling (double) input '{Input}'", input);
 
 			var output = (input / 65535);
 
-			this.LogInformation("Scaled output '{Output}'", output);
+			this.LogDebug("Scaled output '{Output}'", output);
 
 			return output;
 		}

--- a/src/QscQsysDspPlugin.4Series.csproj
+++ b/src/QscQsysDspPlugin.4Series.csproj
@@ -3,13 +3,13 @@
 		<ProjectType>ProgramLibrary</ProjectType>
 	</PropertyGroup>
 	<PropertyGroup>
-		<TargetFramework>net472</TargetFramework>
+		<TargetFramework>net8</TargetFramework>
 		<RootNamespace>QscQsysDspPlugin</RootNamespace>
 		<Deterministic>false</Deterministic>
 		<AssemblyTitle>epi-qsc-qsys</AssemblyTitle>
 		<Company>PepperDash Technologies</Company>
 		<Description>This software is a plugin designed to work as a part of PepperDash Essentials for Crestron control processors. This plugin allows for control of QSC Q-SYS DSP.</Description>
-		<Copyright>Copyright 2025</Copyright>
+		<Copyright>Copyright 2026</Copyright>
 		<Version>3.0.0-local</Version>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<InformationalVersion>$(Version)</InformationalVersion>
@@ -17,13 +17,7 @@
 		<Authors>PepperDash Technologies</Authors>
 		<PackageId>PepperDash.Essentials.Plugins.Qsc.QsysDsp</PackageId>
 		<PackageProjectUrl>https://github.com/PepperDash/epi-qsc-qsysdsp</PackageProjectUrl>
-		<PackageTags>crestron 4series qsc qsys</PackageTags>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DefineConstants>$(DefineConstants);SERIES4</DefineConstants>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DefineConstants>$(DefineConstants);SERIES4</DefineConstants>
+		<PackageTags>crestron 4series net8 qsc qsys</PackageTags>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -38,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PepperDashEssentials" Version="2.13.1" >
+		<PackageReference Include="PepperDashEssentials" Version="3.0.0-dev-v3-testing.13" >
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
 	</ItemGroup>


### PR DESCRIPTION
## Summary

Migrates the QSC Q-Sys DSP plugin from Essentials v2 (`net472`) to Essentials v3 (`net8`).

## Changes

### Project Configuration
- `TargetFramework` `net472` → `net8`
- `PepperDashEssentials` NuGet `2.13.1` → `3.0.0-dev-v3-testing.13`
- Removed `SERIES4` conditional compilation constants

### DeviceFactory
- `MinimumEssentialsFrameworkVersion` `"2.0.0"` → `"3.0.0"`

### Breaking API Fixes
- `Crestron.SimplSharp.Reflection` → `System.Reflection` (3 files)
- Removed `GetCType()` calls — use `.GetType()` directly (2 files)
- `CustomActivate()` `public override` → `protected override`

### Logging Migration (Serilog)
- Migrated all `Debug.Console()` calls to Serilog extension methods (removed in v3)
- `IKeyed` classes use `this.LogError()` / `this.LogInformation()` / `this.LogDebug()`
- Non-`IKeyed` classes use `Debug.LogMessage(LogEventLevel.X, msg, args)`
- Replaced `Debug.ConsoleWithLog()` → `this.LogInformation()`
- Replaced `Debug.ErrorLogLevel` → `Serilog.Events.LogEventLevel`

### Dead Code Removal
- Removed `#if SERIES3` block in `QscDspBridge.cs` (legacy `QscDspDeviceJoinMap : JoinMapBase`)

## Files Changed
| File | Changes |
|------|---------|
| `QscQsysDspPlugin.4Series.csproj` | net8, v3 package, removed SERIES4 defines |
| `QscDspFactory.cs` | MinimumEssentialsFrameworkVersion → 3.0.0 |
| `QscDsp.cs` | Reflection, CustomActivate, ~18 logging calls |
| `QscDspBridge.cs` | SERIES3 removal, ~5 logging calls |
| `QscDspCamera.cs` | ~3 logging calls |
| `QscDspCameraBridge.cs` | ~1 logging call |
| `QscDspDialer.cs` | Reflection, ~5 logging calls |
| `QscDspLevelControl.cs` | ~8 logging calls |

## Testing
- [x] Builds without errors targeting net8
- [x] CPLZ generates correctly (`QscQsysDspPlugin.4Series.3.0.0-local.cplz`)
- [x] Zero remaining `Debug.Console`, `SERIES3`, or `SERIES4` references
- [x] Plugin tested in Essentials v3 runtime

BREAKING CHANGE: Plugin now targets net8 and requires Essentials v3. Not compatible with Essentials v2 (net472) runtime.