### PR TITLE
feat: add functionality to recall and save selected presets by index

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,9 @@ When instantiating multiple dialers joins start @ 3100 and use digital/analog/se
 | dig-o (Input/Triggers)         | I/O         | dig-i (Feedback)                        |
 | ------------------------------ | ----------- | --------------------------------------- |
 |                                | 1           | Is Online Feedback                      |
-| Recall Selected Preset Index   | 91          |                                         |
-| Save Selected Preset Index     | 92          |                                         |
-| Run Preset by Number           | 101 - 300   |                                         |
+| Recall Preset by Number        | 91          |                                         |
+| Save Preset by Number          | 92          |                                         |
+| Recall Preset                  | 101 - 300   |                                         |
 |                                | 200 - 399   | Fader [n] Visible Feedback              |
 | Fader [n] Mute Toggle          | 400 - 599   | Fader [n] Mute Toggle Feedback          |
 | Fader [n] Mute On              | 600 - 799   | Fader [n] Mute On Feedback              |
@@ -376,12 +376,12 @@ When instantiating multiple dialers joins start @ 3100 and use digital/analog/se
 
 #### **Analogs**
 
-| an_o (Input/Triggers)        | I/O       | an_i (Feedback)          |
-| ---------------------------- | --------- | ------------------------ |
-| Recall Selected Preset Index | 91        |                          |
-| Save Selected Preset Index   | 92        |                          |
-| Fader [n] Level Set          | 200 - 399 | Fader [n] Level Feedback |
-|                              | 400 - 599 | Fader [n] Type Feedback  |
+| an_o (Input/Triggers)        | I/O       | an_i (Feedback)     |
+| ----------------------- | --------- | ------------------------ |
+| Recall Preset Number    | 91        |                          |
+| Save Preset Number      | 92        |                          |
+| Fader [n] Level Set     | 200 - 399 | Fader [n] Level Feedback |
+|                         | 400 - 599 | Fader [n] Type Feedback  |
 
 #### **Serials**
 
@@ -389,9 +389,8 @@ When instantiating multiple dialers joins start @ 3100 and use digital/analog/se
 | ------------------------- | --------- | ---------------------------------- |
 | DSP IP Address            | 1         |                                    |
 | DSP Prefix                | 2         |                                    |
-| Recall Preset Index       | 91        |                                    |
-| Save Preset Index         | 92        |                                    |
-| Run Preset by Name        | 100       |                                    |
+| Save Preset by Name       | 92        |                                    |
+| Recall Preset by Name     | 100       |                                    |
 |                           | 101 - 300 | Preset [n] Name Feedback           |
 |                           | 200 - 399 | Fader [n] Name Feedback            |
 |                           | 3100      | Dialer 1 Dial String Feedback      |

--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ When instantiating multiple dialers joins start @ 3100 and use digital/analog/se
 | dig-o (Input/Triggers)         | I/O         | dig-i (Feedback)                        |
 | ------------------------------ | ----------- | --------------------------------------- |
 |                                | 1           | Is Online Feedback                      |
-| Run Preset by Number           | 100 - 199   |                                         |
+| Recall Selected Preset Index   | 91          |                                         |
+| Save Selected Preset Index     | 92          |                                         |
+| Run Preset by Number           | 101 - 300   |                                         |
 |                                | 200 - 399   | Fader [n] Visible Feedback              |
 | Fader [n] Mute Toggle          | 400 - 599   | Fader [n] Mute Toggle Feedback          |
 | Fader [n] Mute On              | 600 - 799   | Fader [n] Mute On Feedback              |
@@ -374,10 +376,12 @@ When instantiating multiple dialers joins start @ 3100 and use digital/analog/se
 
 #### **Analogs**
 
-| an_o (Input/Triggers) | I/O       | an_i (Feedback)          |
-| --------------------- | --------- | ------------------------ |
-| Fader [n] Level Set   | 200 - 399 | Fader [n] Level Feedback |
-|                       | 400 - 599 | Fader [n] Type Feedback  |
+| an_o (Input/Triggers)        | I/O       | an_i (Feedback)          |
+| ---------------------------- | --------- | ------------------------ |
+| Recall Selected Preset Index | 91        |                          |
+| Save Selected Preset Index   | 92        |                          |
+| Fader [n] Level Set          | 200 - 399 | Fader [n] Level Feedback |
+|                              | 400 - 599 | Fader [n] Type Feedback  |
 
 #### **Serials**
 
@@ -385,8 +389,9 @@ When instantiating multiple dialers joins start @ 3100 and use digital/analog/se
 | ------------------------- | --------- | ---------------------------------- |
 | DSP IP Address            | 1         |                                    |
 | DSP Prefix                | 2         |                                    |
+| Save Preset by Name       | 92        |                                    |
 | Run Preset by Name        | 100       |                                    |
-|                           | 100 - 199 | Preset [n] Name Feedback           |
+|                           | 101 - 300 | Preset [n] Name Feedback           |
 |                           | 200 - 399 | Fader [n] Name Feedback            |
 |                           | 3100      | Dialer 1 Dial String Feedback      |
 |                           | 3104      | Dialer 1 Caller ID Number Feedback |

--- a/README.md
+++ b/README.md
@@ -389,7 +389,8 @@ When instantiating multiple dialers joins start @ 3100 and use digital/analog/se
 | ------------------------- | --------- | ---------------------------------- |
 | DSP IP Address            | 1         |                                    |
 | DSP Prefix                | 2         |                                    |
-| Save Preset by Name       | 92        |                                    |
+| Recall Preset Index       | 91        |                                    |
+| Save Preset Index         | 92        |                                    |
 | Run Preset by Name        | 100       |                                    |
 |                           | 101 - 300 | Preset [n] Name Feedback           |
 |                           | 200 - 399 | Fader [n] Name Feedback            |

--- a/src/QscDsp.cs
+++ b/src/QscDsp.cs
@@ -653,7 +653,13 @@ namespace QscQsysDspPlugin
         /// <param name="n">ushort</param>
         public void RunPresetNumber(ushort n)
         {
-            RunPreset(PresetList[n].Preset);
+            var preset = PresetList[n];
+            if (string.IsNullOrEmpty(preset.Preset))
+            {
+                this.LogError("Cannot recall preset at index {0}: preset name is not defined", n);
+                return;
+            }
+            RunPreset(preset.Preset);
         }
 
         /// <summary>
@@ -691,10 +697,21 @@ namespace QscQsysDspPlugin
         /// <param name="n">ushort</param>
         public void SavePresetNumber(ushort n)
         {
-            // assuming the preset configuration is "SNAPSsHOT_BANK SNAPSHOT_NUM FLOTATING_POINT_NUM"
-            // we need to revome the floating point number parameter when saving
+            var preset = PresetList[n];
+            if (string.IsNullOrEmpty(preset.Preset))
+            {
+                this.LogError("Cannot save preset at index {0}: preset name is not defined", n);
+                return;
+            }
+            // assuming the preset configuration is "SNAPSHOT_BANK SNAPSHOT_NUM FLOATING_POINT_NUM"
+            // we need to remove the floating point number parameter when saving
             // split the preset on ' ' (\x20) and only use the 1st two indexes which should be the SNAPSHOT_BANK and SNAPSHOT_NUM
-            var cmd = PresetList[n].Preset.Split(' ');
+            var cmd = preset.Preset.Split(' ');
+            if (cmd.Length < 2)
+            {
+                this.LogError("Cannot save preset at index {0}: preset name '{1}' is not in the expected 'BANK NUMBER' format", n, preset.Preset);
+                return;
+            }
             SavePreset(string.Format("{0} {1}", cmd[0], cmd[1]));
         }
 

--- a/src/QscDspBridge.cs
+++ b/src/QscDspBridge.cs
@@ -96,11 +96,10 @@ namespace QscQsysDspPlugin
 			x = 0;
 			// from SiMPL > to Plugin
             trilist.SetStringSigAction(joinMap.PresetsByName.JoinNumber, DspDevice.RunPreset);
-            trilist.SetStringSigAction(joinMap.RecallPresetIndex.JoinNumber, DspDevice.RunPreset);
-            trilist.SetStringSigAction(joinMap.SavePresetIndex.JoinNumber, DspDevice.SavePreset);
-            trilist.SetUShortSigAction(joinMap.SelectedPresetRecallIndex.JoinNumber, value => selectedPresetToRecall = value);
-            trilist.SetUShortSigAction(joinMap.SelectedPresetSaveIndex.JoinNumber, value => selectedPresetToSave = value);
-            trilist.SetSigTrueAction(joinMap.SelectedPresetRecall.JoinNumber, () =>
+            trilist.SetStringSigAction(joinMap.SavePresetsByName.JoinNumber, DspDevice.SavePreset);
+            trilist.SetUShortSigAction(joinMap.PresetRecallNumber.JoinNumber, value => selectedPresetToRecall = value);
+            trilist.SetUShortSigAction(joinMap.PresetSaveNumber.JoinNumber, value => selectedPresetToSave = value);
+            trilist.SetSigTrueAction(joinMap.RecallPresetByNumber.JoinNumber, () =>
             {
                 ushort presetIndex;
                 if (TryGetPresetIndex(DspDevice, selectedPresetToRecall, "recall", out presetIndex))
@@ -108,7 +107,7 @@ namespace QscQsysDspPlugin
                     DspDevice.RunPresetNumber(presetIndex);
                 }
             });
-            trilist.SetSigTrueAction(joinMap.SelectedPresetSave.JoinNumber, () =>
+            trilist.SetSigTrueAction(joinMap.SavePresetByNumber.JoinNumber, () =>
             {
                 ushort presetIndex;
                 if (TryGetPresetIndex(DspDevice, selectedPresetToSave, "save", out presetIndex))
@@ -471,8 +470,8 @@ namespace QscQsysDspPlugin
                 JoinType = eJoinType.DigitalSerial
             });
 
-        [JoinName("SelectedPresetRecall")]
-        public JoinDataComplete SelectedPresetRecall = new JoinDataComplete(
+        [JoinName("RecallPresetByNumber")]
+        public JoinDataComplete RecallPresetByNumber = new JoinDataComplete(
             new JoinData
             {
                 JoinNumber = 91,
@@ -480,13 +479,13 @@ namespace QscQsysDspPlugin
             },
             new JoinMetadata
             {
-                Description = "Trigger recall of selected preset",
+                Description = "Recall the preset by number",
                 JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Digital
             });
 
-        [JoinName("SelectedPresetRecallIndex")]
-        public JoinDataComplete SelectedPresetRecallIndex = new JoinDataComplete(
+        [JoinName("PresetRecallNumber")]
+        public JoinDataComplete PresetRecallNumber = new JoinDataComplete(
             new JoinData
             {
                 JoinNumber = 91,
@@ -494,27 +493,13 @@ namespace QscQsysDspPlugin
             },
             new JoinMetadata
             {
-                Description = "Preset index to recall",
+                Description = "Preset number to recall",
                 JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Analog
             });
 
-        [JoinName("RecallPresetIndex")]
-        public JoinDataComplete RecallPresetIndex = new JoinDataComplete(
-            new JoinData
-            {
-                JoinNumber = 91,
-                JoinSpan = 1
-            },
-            new JoinMetadata
-            {
-                Description = "Recall preset by index (bank number format)",
-                JoinCapabilities = eJoinCapabilities.FromSIMPL,
-                JoinType = eJoinType.Serial
-            });
-
-        [JoinName("SelectedPresetSave")]
-        public JoinDataComplete SelectedPresetSave = new JoinDataComplete(
+        [JoinName("SavePresetByNumber")]
+        public JoinDataComplete SavePresetByNumber = new JoinDataComplete(
             new JoinData
             {
                 JoinNumber = 92,
@@ -522,13 +507,13 @@ namespace QscQsysDspPlugin
             },
             new JoinMetadata
             {
-                Description = "Trigger save of selected preset",
+                Description = "Save the preset by number",
                 JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Digital
             });
 
-        [JoinName("SelectedPresetSaveIndex")]
-        public JoinDataComplete SelectedPresetSaveIndex = new JoinDataComplete(
+        [JoinName("PresetSaveNumber")]
+        public JoinDataComplete PresetSaveNumber = new JoinDataComplete(
             new JoinData
             {
                 JoinNumber = 92,
@@ -536,13 +521,13 @@ namespace QscQsysDspPlugin
             },
             new JoinMetadata
             {
-                Description = "Preset index to save",
+                Description = "Preset number to save",
                 JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Analog
             });
 
-        [JoinName("SavePresetIndex")]
-        public JoinDataComplete SavePresetIndex = new JoinDataComplete(
+        [JoinName("SavePresetsByName")]
+        public JoinDataComplete SavePresetsByName = new JoinDataComplete(
             new JoinData
             {
                 JoinNumber = 92,
@@ -550,7 +535,7 @@ namespace QscQsysDspPlugin
             },
             new JoinMetadata
             {
-                Description = "Save preset by index (bank number format)",
+                Description = "Save presets by name",
                 JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Serial
             });

--- a/src/QscDspBridge.cs
+++ b/src/QscDspBridge.cs
@@ -28,6 +28,8 @@ namespace QscQsysDspPlugin
             //    joinMap = new QscDspCameraDeviceJoinMap();
             Debug.Console(1, DspDevice, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 			ushort x = 0;
+            ushort selectedPresetToRecall = 0;
+            ushort selectedPresetToSave = 0;
 			var comm = DspDevice as ICommunicationMonitor;
 
 			// from Plugin > to SiMPL
@@ -94,6 +96,25 @@ namespace QscQsysDspPlugin
 			x = 0;
 			// from SiMPL > to Plugin
             trilist.SetStringSigAction(joinMap.PresetsByName.JoinNumber, DspDevice.RunPreset);
+            trilist.SetStringSigAction(joinMap.SelectedPresetSaveByName.JoinNumber, DspDevice.SavePreset);
+            trilist.SetUShortSigAction(joinMap.SelectedPresetRecallIndex.JoinNumber, value => selectedPresetToRecall = value);
+            trilist.SetUShortSigAction(joinMap.SelectedPresetSaveIndex.JoinNumber, value => selectedPresetToSave = value);
+            trilist.SetSigTrueAction(joinMap.SelectedPresetRecall.JoinNumber, () =>
+            {
+                ushort presetIndex;
+                if (TryGetPresetIndex(DspDevice, selectedPresetToRecall, "recall", out presetIndex))
+                {
+                    DspDevice.RunPresetNumber(presetIndex);
+                }
+            });
+            trilist.SetSigTrueAction(joinMap.SelectedPresetSave.JoinNumber, () =>
+            {
+                ushort presetIndex;
+                if (TryGetPresetIndex(DspDevice, selectedPresetToSave, "save", out presetIndex))
+                {
+                    DspDevice.SavePresetNumber(presetIndex);
+                }
+            });
 			foreach (var preset in DspDevice.PresetList)
 			{
 				var temp = x;
@@ -101,7 +122,6 @@ namespace QscQsysDspPlugin
 				// from SiMPL > to Plugin
 				trilist.StringInput[presetNum].StringValue = preset.Label;
 				trilist.SetSigTrueAction(presetNum, () => DspDevice.RunPresetNumber(temp));
-                // trilist.SetSigHeldAction(presetNum, 5000, () => DspDevice.SavePresetNumber(temp), () => DspDevice.RunPresetNumber(temp));
 				x++;
 			}
 
@@ -168,6 +188,27 @@ namespace QscQsysDspPlugin
 				lineOffset = lineOffset + 50;
 			}
 		}
+
+        private static bool TryGetPresetIndex(QscDsp dspDevice, ushort selectedPreset, string action, out ushort presetIndex)
+        {
+            presetIndex = 0;
+
+            if (selectedPreset == 0)
+            {
+                Debug.Console(1, dspDevice, "Ignoring preset {0}; selected preset index is 0 and must be one-based", action);
+                return false;
+            }
+
+            if (selectedPreset > dspDevice.PresetList.Count)
+            {
+                Debug.Console(1, dspDevice, "Ignoring preset {0}; selected preset index {1} is outside the available range 1-{2}",
+                    action, selectedPreset, dspDevice.PresetList.Count);
+                return false;
+            }
+
+            presetIndex = (ushort)(selectedPreset - 1);
+            return true;
+        }
 	}
 
 #if SERIES3
@@ -424,9 +465,79 @@ namespace QscQsysDspPlugin
             },
             new JoinMetadata
             {
-                Description = "Trigger / Save presets and Preset Name",
+                Description = "Recall presets and preset names",
                 JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
                 JoinType = eJoinType.DigitalSerial
+            });
+
+        [JoinName("SelectedPresetRecall")]
+        public JoinDataComplete SelectedPresetRecall = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 91,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Trigger recall of selected preset",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("SelectedPresetRecallIndex")]
+        public JoinDataComplete SelectedPresetRecallIndex = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 91,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Preset index to recall",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("SelectedPresetSave")]
+        public JoinDataComplete SelectedPresetSave = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 92,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Trigger save of selected preset",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("SelectedPresetSaveIndex")]
+        public JoinDataComplete SelectedPresetSaveIndex = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 92,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Preset index to save",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("SelectedPresetSaveByName")]
+        public JoinDataComplete SelectedPresetSaveByName = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 92,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Save preset by name",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Serial
             });
 
         [JoinName("PresetsByName")]

--- a/src/QscDspBridge.cs
+++ b/src/QscDspBridge.cs
@@ -96,7 +96,8 @@ namespace QscQsysDspPlugin
 			x = 0;
 			// from SiMPL > to Plugin
             trilist.SetStringSigAction(joinMap.PresetsByName.JoinNumber, DspDevice.RunPreset);
-            trilist.SetStringSigAction(joinMap.SelectedPresetSaveByName.JoinNumber, DspDevice.SavePreset);
+            trilist.SetStringSigAction(joinMap.RecallPresetIndex.JoinNumber, DspDevice.RunPreset);
+            trilist.SetStringSigAction(joinMap.SavePresetIndex.JoinNumber, DspDevice.SavePreset);
             trilist.SetUShortSigAction(joinMap.SelectedPresetRecallIndex.JoinNumber, value => selectedPresetToRecall = value);
             trilist.SetUShortSigAction(joinMap.SelectedPresetSaveIndex.JoinNumber, value => selectedPresetToSave = value);
             trilist.SetSigTrueAction(joinMap.SelectedPresetRecall.JoinNumber, () =>
@@ -498,6 +499,20 @@ namespace QscQsysDspPlugin
                 JoinType = eJoinType.Analog
             });
 
+        [JoinName("RecallPresetIndex")]
+        public JoinDataComplete RecallPresetIndex = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 91,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Recall preset by index (bank number format)",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
         [JoinName("SelectedPresetSave")]
         public JoinDataComplete SelectedPresetSave = new JoinDataComplete(
             new JoinData
@@ -526,8 +541,8 @@ namespace QscQsysDspPlugin
                 JoinType = eJoinType.Analog
             });
 
-        [JoinName("SelectedPresetSaveByName")]
-        public JoinDataComplete SelectedPresetSaveByName = new JoinDataComplete(
+        [JoinName("SavePresetIndex")]
+        public JoinDataComplete SavePresetIndex = new JoinDataComplete(
             new JoinData
             {
                 JoinNumber = 92,
@@ -535,7 +550,7 @@ namespace QscQsysDspPlugin
             },
             new JoinMetadata
             {
-                Description = "Save preset by name",
+                Description = "Save preset by index (bank number format)",
                 JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Serial
             });


### PR DESCRIPTION
PR extends DSP EPI functionality to allow saving snapshots (previously only able to recall). Functionality is backwards compatible and has no breaking changes. Functionality extended to also include option to recall or save snapshot by providing analog index bridge value and requires digital trigger to recall/save snapshot at desired index. 